### PR TITLE
Add tol parameter to remove flattening tolerance constant

### DIFF
--- a/svg2polylines-ffi/example.c
+++ b/svg2polylines-ffi/example.c
@@ -25,7 +25,7 @@ typedef struct Polyline {
     size_t len;
 } Polyline;
 
-uint8_t svg_str_to_polylines(char* svg, Polyline** polylines, size_t* polylines_len);
+uint8_t svg_str_to_polylines(char* svg, double tol, Polyline** polylines, size_t* polylines_len);
 void free_polylines(Polyline* polylines, size_t polylines_len);
 
 
@@ -53,7 +53,7 @@ int main() {
     size_t polylines_len = 0;
 
     // Process data
-    uint8_t err = svg_str_to_polylines(input, &polylines, &polylines_len);
+    uint8_t err = svg_str_to_polylines(input, 0.15, &polylines, &polylines_len);
 
     // Error handling
     if (err > 0) {

--- a/svg2polylines-ffi/example.py
+++ b/svg2polylines-ffi/example.py
@@ -14,7 +14,7 @@ typedef struct Polyline {
     size_t len;
 } Polyline;
 
-uint8_t svg_str_to_polylines(char* svg, Polyline** polylines, size_t* polylines_len);
+uint8_t svg_str_to_polylines(char* svg, double tol, Polyline** polylines, size_t* polylines_len);
 void free_polylines(Polyline* polylines, size_t polylines_len);
 ''')
 
@@ -47,7 +47,7 @@ def print_polyline(p):
 
 polylines = ffi.new('Polyline**')
 polylines_len = ffi.new('size_t*')
-lib.svg_str_to_polylines(svg_input, polylines, polylines_len)
+lib.svg_str_to_polylines(svg_input, 0.15, polylines, polylines_len)
 
 
 print('Found %d polylines!' % polylines_len[0])

--- a/svg2polylines-ffi/src/lib.rs
+++ b/svg2polylines-ffi/src/lib.rs
@@ -3,7 +3,7 @@
 use std::ffi::CStr;
 use std::mem;
 
-use libc::{c_char, size_t};
+use libc::{c_char, c_double, size_t};
 use svg2polylines::{parse, CoordinatePair};
 
 /// Structure that contains a pointer to the coordinate pairs as well as the
@@ -37,6 +37,7 @@ pub struct Polyline {
 #[no_mangle]
 pub unsafe extern "C" fn svg_str_to_polylines(
     svg: *const c_char,
+    tol: c_double,
     polylines: *mut *mut Polyline,
     polylines_len: *mut size_t,
 ) -> u8 {
@@ -48,7 +49,7 @@ pub unsafe extern "C" fn svg_str_to_polylines(
     let r_str = c_str.to_str().unwrap();
 
     // Process
-    match parse(r_str) {
+    match parse(r_str, tol) {
         Ok(vec) => {
             // Convert `Vec<Vec<CoordinatePair>>` to `Vec<Polyline>`
             let mut tmp_vec: Vec<Polyline> = vec

--- a/svg2polylines/examples/basic.rs
+++ b/svg2polylines/examples/basic.rs
@@ -25,7 +25,7 @@ fn main() {
     file.read_to_string(&mut s).unwrap();
 
     // Parse data
-    let polylines: Vec<Polyline> = svg2polylines::parse(&s).unwrap_or_else(|e| {
+    let polylines: Vec<Polyline> = svg2polylines::parse(&s, 0.15).unwrap_or_else(|e| {
         println!("Error: {}", e);
         exit(2);
     });

--- a/svg2polylines/examples/preview.rs
+++ b/svg2polylines/examples/preview.rs
@@ -30,7 +30,7 @@ fn main() {
     file.read_to_string(&mut s).unwrap();
 
     // Parse data
-    let polylines: Vec<Polyline> = svg2polylines::parse(&s).unwrap_or_else(|e| {
+    let polylines: Vec<Polyline> = svg2polylines::parse(&s, 0.15).unwrap_or_else(|e| {
         println!("Error: {}", e);
         exit(2);
     });

--- a/svg2polylines/src/lib.rs
+++ b/svg2polylines/src/lib.rs
@@ -10,6 +10,8 @@
 //! **Note: Currently the path style is completely ignored. Only the path itself is
 //! returned.**
 //!
+//! Minimal supported Rust version: 1.31 (Rust 2018).
+//!
 //! FFI bindings for this crate can be found [on
 //! Github](https://github.com/dbrgn/svg2polylines).
 //!
@@ -864,17 +866,50 @@ mod tests {
         assert_eq!(
             result[0],
             vec![
-                CoordinatePair::new(0.10650371, 93.221877),
-                CoordinatePair::new(0.10650371, 93.221877),
-                CoordinatePair::new(1.0590999115751005, 92.1819684952793),
-                CoordinatePair::new(5.370943458862083, 89.70221166323438),
-                CoordinatePair::new(8.823669349110439, 89.5489159835669),
-                CoordinatePair::new(9.72849, 89.74737800000001),
-                CoordinatePair::new(12.282201899791776, 90.98899075432975),
-                CoordinatePair::new(13.679358042116176, 92.76458821557513),
-                CoordinatePair::new(14.196220298368665, 94.94365381717776),
-                CoordinatePair::new(14.023847964560911, 96.8907337998339),
-                CoordinatePair::new(14.004928, 96.96365600000001),
+                CoordinatePair {
+                    x: 0.10650371,
+                    y: 93.221877
+                },
+                CoordinatePair {
+                    x: 0.10650371,
+                    y: 93.221877
+                },
+                CoordinatePair {
+                    x: 1.0590999115751005,
+                    y: 92.1819684952793
+                },
+                CoordinatePair {
+                    x: 5.370943458862083,
+                    y: 89.70221166323438
+                },
+                CoordinatePair {
+                    x: 8.823669349110439,
+                    y: 89.5489159835669
+                },
+                CoordinatePair {
+                    x: 9.72849,
+                    y: 89.74737800000001
+                },
+                CoordinatePair {
+                    x: 12.282201899791776,
+                    y: 90.98899075432975
+                },
+                CoordinatePair {
+                    x: 13.679358042116176,
+                    y: 92.76458821557513
+                },
+                CoordinatePair {
+                    x: 14.196220298368665,
+                    y: 94.94365381717776
+                },
+                CoordinatePair {
+                    x: 14.023847964560911,
+                    y: 96.8907337998339
+                },
+                CoordinatePair {
+                    x: 14.004928,
+                    y: 96.96365600000001
+                },
             ]
         );
     }
@@ -898,37 +933,121 @@ mod tests {
         assert_eq!(
             result[0],
             vec![
-                CoordinatePair::new(10.0, 80.0),
-                CoordinatePair::new(18.274009596865902, 62.23607902107565),
-                CoordinatePair::new(25.54854286110641, 49.356797920419545),
-                CoordinatePair::new(32.00061859514943, 40.276471430451714),
-                CoordinatePair::new(37.76877706571886, 34.14452804422132),
-                CoordinatePair::new(42.977786748045155, 30.28862586112818),
-                CoordinatePair::new(47.75948795454129, 28.192810777806955),
-                CoordinatePair::new(52.26776775705932, 27.50166400871596),
-                CoordinatePair::new(56.67911619890174, 28.03853054445934),
-                CoordinatePair::new(61.17477190430957, 29.815620388680145),
-                CoordinatePair::new(65.91841423291706, 33.02014722137494),
-                CoordinatePair::new(71.04736316596855, 37.986586554742004),
-                CoordinatePair::new(76.67889180557972, 45.17533085552483),
-                CoordinatePair::new(82.92363487320814, 55.16763405833094),
-                CoordinatePair::new(89.90077281862139, 68.67838317092607),
-                CoordinatePair::new(95.0, 80.0),
-                CoordinatePair::new(103.2740095968659, 97.76392097892435),
-                CoordinatePair::new(110.5485428611064, 110.64320207958045),
-                CoordinatePair::new(117.00061859514942, 119.72352856954828),
-                CoordinatePair::new(122.76877706571884, 125.85547195577867),
-                CoordinatePair::new(127.97778674804515, 129.7113741388718),
-                CoordinatePair::new(132.7594879545413, 131.80718922219302),
-                CoordinatePair::new(137.26776775705935, 132.49833599128402),
-                CoordinatePair::new(141.67911619890177, 131.96146945554065),
-                CoordinatePair::new(146.17477190430958, 130.18437961131986),
-                CoordinatePair::new(150.91841423291706, 126.97985277862506),
-                CoordinatePair::new(156.04736316596853, 122.01341344525798),
-                CoordinatePair::new(161.67889180557972, 114.82466914447512),
-                CoordinatePair::new(167.92363487320813, 104.83236594166902),
-                CoordinatePair::new(174.90077281862128, 91.32161682907416),
-                CoordinatePair::new(180.0, 80.0),
+                CoordinatePair { x: 10.0, y: 80.0 },
+                CoordinatePair {
+                    x: 18.274009596865902,
+                    y: 62.23607902107565
+                },
+                CoordinatePair {
+                    x: 25.54854286110641,
+                    y: 49.356797920419545
+                },
+                CoordinatePair {
+                    x: 32.00061859514943,
+                    y: 40.276471430451714
+                },
+                CoordinatePair {
+                    x: 37.76877706571886,
+                    y: 34.14452804422132
+                },
+                CoordinatePair {
+                    x: 42.977786748045155,
+                    y: 30.28862586112818
+                },
+                CoordinatePair {
+                    x: 47.75948795454129,
+                    y: 28.192810777806955
+                },
+                CoordinatePair {
+                    x: 52.26776775705932,
+                    y: 27.50166400871596
+                },
+                CoordinatePair {
+                    x: 56.67911619890174,
+                    y: 28.03853054445934
+                },
+                CoordinatePair {
+                    x: 61.17477190430957,
+                    y: 29.815620388680145
+                },
+                CoordinatePair {
+                    x: 65.91841423291706,
+                    y: 33.02014722137494
+                },
+                CoordinatePair {
+                    x: 71.04736316596855,
+                    y: 37.986586554742004
+                },
+                CoordinatePair {
+                    x: 76.67889180557972,
+                    y: 45.17533085552483
+                },
+                CoordinatePair {
+                    x: 82.92363487320814,
+                    y: 55.16763405833094
+                },
+                CoordinatePair {
+                    x: 89.90077281862139,
+                    y: 68.67838317092607
+                },
+                CoordinatePair { x: 95.0, y: 80.0 },
+                CoordinatePair {
+                    x: 103.2740095968659,
+                    y: 97.76392097892435
+                },
+                CoordinatePair {
+                    x: 110.5485428611064,
+                    y: 110.64320207958045
+                },
+                CoordinatePair {
+                    x: 117.00061859514942,
+                    y: 119.72352856954828
+                },
+                CoordinatePair {
+                    x: 122.76877706571884,
+                    y: 125.85547195577867
+                },
+                CoordinatePair {
+                    x: 127.97778674804515,
+                    y: 129.7113741388718
+                },
+                CoordinatePair {
+                    x: 132.7594879545413,
+                    y: 131.80718922219302
+                },
+                CoordinatePair {
+                    x: 137.26776775705935,
+                    y: 132.49833599128402
+                },
+                CoordinatePair {
+                    x: 141.67911619890177,
+                    y: 131.96146945554065
+                },
+                CoordinatePair {
+                    x: 146.17477190430958,
+                    y: 130.18437961131986
+                },
+                CoordinatePair {
+                    x: 150.91841423291706,
+                    y: 126.97985277862506
+                },
+                CoordinatePair {
+                    x: 156.04736316596853,
+                    y: 122.01341344525798
+                },
+                CoordinatePair {
+                    x: 161.67889180557972,
+                    y: 114.82466914447512
+                },
+                CoordinatePair {
+                    x: 167.92363487320813,
+                    y: 104.83236594166902
+                },
+                CoordinatePair {
+                    x: 174.90077281862128,
+                    y: 91.32161682907416
+                },
+                CoordinatePair { x: 180.0, y: 80.0 },
             ]
         );
     }


### PR DESCRIPTION
This PR adds the feature, but sometime adds the `tol` parameter to an already long list of arguments.

The other option I see is to create a struct and add functions there, but this has a downside on the FFI simplicity.

Feel free to close the PR if you are not interested in the patch or ask for modifications if you are!