### PR TITLE
Preprocess with usvg (support for shapes and transforms)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ lyon_geom = "0.17"
 quick-xml = "0.23"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 svgtypes = "0.8"
+usvg = "0.23"
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This can be used e.g. for simple drawing robot that just support drawing
 straight lines and liftoff / drop pen commands.
 
 Flattening of Bézier curves is done using the
-[Lyon](https://github.com/nical/lyon) library.
+[Lyon](https://github.com/nical/lyon) library. SVG files are preprocessed /
+simplified using [usvg](https://docs.rs/usvg/).
 
 **Note: Currently the path style is completely ignored. Only the path itself is
 returned.**
@@ -35,7 +36,7 @@ Use the mouse to drag the image and the `Esc` key to close the window.
 Signature:
 
 ```rust
-fn svg2polylines::parse(&str) -> Result<Vec<Polyline>, String>;
+fn svg2polylines::parse(svg: &str, tol: f64, preprocess: bool) -> Result<Vec<Polyline>, String>;
 ```
 
 See [`examples/basic.rs`][example-src] for a full usage example.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cargo run --release --example preview path/to/file.svg
 
 The `--release` parameter is important, otherwise it's going to be very slow.
 
-Use the mouse to drag the image and the `Esc` key to close the window.
+Use the mouse to drag / zoom the image and the `Esc` key to close the window.
 
 
 ## Usage: Rust

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -25,7 +25,7 @@ fn main() {
     file.read_to_string(&mut s).unwrap();
 
     // Parse data
-    let polylines: Vec<Polyline> = svg2polylines::parse(&s, 0.15).unwrap_or_else(|e| {
+    let polylines: Vec<Polyline> = svg2polylines::parse(&s, 0.15, true).unwrap_or_else(|e| {
         println!("Error: {}", e);
         exit(2);
     });

--- a/examples/preview.rs
+++ b/examples/preview.rs
@@ -28,7 +28,7 @@ fn main() {
     file.read_to_string(&mut s).unwrap();
 
     // Parse data
-    let polylines: Vec<Polyline> = svg2polylines::parse(&s, 0.15).unwrap_or_else(|e| {
+    let polylines: Vec<Polyline> = svg2polylines::parse(&s, 0.15, true).unwrap_or_else(|e| {
         println!("Error: {}", e);
         exit(2);
     });

--- a/examples/preview.rs
+++ b/examples/preview.rs
@@ -92,7 +92,7 @@ fn main() {
         window.draw_2d(&e, |ctx, g, _device| {
             clear([1.0; 4], g);
             for polyline in &polylines {
-                for pair in polyline.windows(2) {
+                for pair in polyline.as_ref().windows(2) {
                     line(
                         black,
                         radius,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,12 +5,17 @@
 //! straight lines and liftoff / drop pen commands.
 //!
 //! Flattening of Bézier curves is done using the
-//! [Lyon](https://github.com/nical/lyon) library.
+//! [Lyon](https://github.com/nical/lyon) library. SVG files are preprocessed /
+//! simplified using [usvg](https://docs.rs/usvg/).
 //!
 //! **Note: Currently the path style is completely ignored. Only the path itself is
 //! returned.**
 //!
-//! Minimal supported Rust version: 1.31 (Rust 2018).
+//! ## MSRV
+//!
+//! This library does not guarantee a fixed MSRV.
+//!
+//! ## Serialization
 //!
 //! You can optionally get serde 1 support by enabling the `serde` feature.
 


### PR DESCRIPTION
Preprocess the SVGs with [usvg](https://docs.rs/usvg). This gives us a whole lot of new features:

- Support for shapes (like circles, rectangles, etc)
- Support for transforms
- Other less often used SVG features

All transforms are converted to matrix transforms by usvg. They're then applied to the polyline using [euclid::Transform2D](https://docs.rs/euclid/0.22.7/euclid/struct.Transform2D.html).

Thanks @naufraghi for the initial work on this!

Fixes #18.