### PR TITLE
Allow dump data from SVG paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,15 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 svgtypes = "0.8"
 thiserror = "1"
 usvg = "0.23"
+csv = { version = "1.1", optional = true, features = [] }
 
 [dev-dependencies]
 env_logger = "0.9"
 serde_json = "1"
 piston_window = "0.124"
 piston2d-drag_controller = "0.30"
+
+[[example]]
+name = "svg2csv"
+path = "examples/svg2csv.rs"
+required-features = ["serde", "csv"]

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -25,7 +25,7 @@ fn main() {
     file.read_to_string(&mut s).unwrap();
 
     // Parse data
-    let polylines: Vec<Polyline> = svg2polylines::parse(&s, 0.15, true).unwrap_or_else(|e| {
+    let polylines: Vec<(Option<String>, Polyline)> = svg2polylines::parse(&s, 0.15, true).unwrap_or_else(|e| {
         println!("Error: {}", e);
         exit(2);
     });

--- a/examples/preview.rs
+++ b/examples/preview.rs
@@ -28,7 +28,7 @@ fn main() {
     file.read_to_string(&mut s).unwrap();
 
     // Parse data
-    let polylines: Vec<Polyline> = svg2polylines::parse(&s, 0.15, true).unwrap_or_else(|e| {
+    let polylines: Vec<(Option<String>, Polyline)> = svg2polylines::parse(&s, 0.15, true).unwrap_or_else(|e| {
         println!("Error: {}", e);
         exit(2);
     });
@@ -91,7 +91,7 @@ fn main() {
         // Redraw
         window.draw_2d(&e, |ctx, g, _device| {
             clear([1.0; 4], g);
-            for polyline in &polylines {
+            for (_id, polyline) in &polylines {
                 for pair in polyline.as_ref().windows(2) {
                     line(
                         black,

--- a/examples/svg2csv.rs
+++ b/examples/svg2csv.rs
@@ -1,0 +1,50 @@
+use std::env;
+use std::fs;
+use std::io::Read;
+use std::process::exit;
+
+use svg2polylines::{self, Polyline};
+
+use csv::Writer;
+
+fn main() {
+    // Logging
+    env_logger::init();
+
+    // Argument parsing
+    let args: Vec<_> = env::args().collect();
+    match args.len() {
+        2 => {}
+        _ => {
+            println!("Usage: {} <path/to/file.svg>", args[0]);
+            exit(1);
+        }
+    };
+
+    // Load file
+    let mut file = fs::File::open(&args[1]).unwrap();
+    let mut s = String::new();
+    file.read_to_string(&mut s).unwrap();
+
+    // Parse data
+    let polylines: Vec<(Option<String>, Polyline)> = svg2polylines::parse(&s, 0.15, true).unwrap_or_else(|e| {
+        println!("Error: {}", e);
+        exit(2);
+    });
+
+    // Print data
+    println!("Found {} polylines.", polylines.len());
+    for (num, (id, line)) in polylines.iter().enumerate() {
+        let filename = if let Some(id_str) = id {
+            format!("{}_{}.csv", id_str, num)
+        } else {
+            format!("unk_{}.csv", num)
+        };
+
+        let mut wtr = Writer::from_path(filename).unwrap();
+        for row in line {
+            wtr.serialize(row).unwrap();
+        }
+        wtr.flush().unwrap();
+    }
+}


### PR DESCRIPTION
When we have a research article in PDF format with some plot, it may be desirable to convert this plot back to the data in order to make further processing or validating. The plot can be saved to SVG format using any vector editor (like inkscape).

Here we introduce parsing `id` attributes of `path` tags to associate polylines back with required geometrical objects and provide example how to write csv files.